### PR TITLE
Less case sensitive header name (browser compatibility)

### DIFF
--- a/authorizer.js
+++ b/authorizer.js
@@ -1,6 +1,8 @@
 exports.handler = function (event, context, callback) {
   var authorizationHeader = event.headers.Authorization
 
+  if (!authorizationHeader) authorizationHeader = event.headers.authorization
+
   if (!authorizationHeader) return callback('Unauthorized')
 
   var encodedCreds = authorizationHeader.split(' ')[1]


### PR DESCRIPTION
Hi David!

Thanks a lot for bringing this useful tutorial together (referring to the [Medium article](https://medium.com/@Da_vidgf/http-basic-auth-with-api-gateway-and-serverless-5ae14ad0a270))!

In the comments someone mentions - and this is as well my experience in practice with Firefox - that the Authorization header with the credentials reaches the authorizer in all lower case. I also checked with a recent/latest Chromium, it was the same, this commit obviously addresses that.

(And a second note: I am uncertain whether it is a useful suggestion in such illustrative scenarios, but some LICENSE could be useful for this repo as well. I am planning to put a lot of the code to good use for a temporary in-house solution - I pulled a lot of hair out over trying to integrate Cognito for no serious immediate need :) so I guess it can come useful for others too. Of course feel free to ignore this part if you disagree for any reason.)
